### PR TITLE
Create basic dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:latest
 WORKDIR /iperf
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt update && apt-get install -y gcc && apt-get --no-install-recommends install -y make
 COPY . .
-RUN apt-get update && apt-get install -y gcc
-RUN apt-get install -y make
 RUN ./bootstrap.sh && ./configure && make && make install
 CMD ["./src/iperf3", "-s"]


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

#4

* Brief description of code changes (suitable for use as a commit message):

Created a basic Dockerfile. It runs in Ubuntu, installs the necessary apt packages (gcc and make) and caches them for quickly rebuilding the image, makes the files, and runs an iPerf server.

Running the image with `docker run -dp 5201:5201 <image-name>` lets the user ping it with `./src/iperf3 -c 127.0.0.1 -p 5201`.

`--no-install-recommends` was added to the make installation to speed it up. Configuring the project failed when this was applied to the gcc installation, so it was left out there.