### PR TITLE
Add QUIC protocol with ID and name that will display in JSON output with new flags

### DIFF
--- a/experiment/baseline_quic.py
+++ b/experiment/baseline_quic.py
@@ -1,6 +1,0 @@
-import subprocess
-
-subprocess.run(
-    "./src/iperf3 -c localhost -p 5201 --quic --json --logfile ./output/baseline_quic.log",
-    shell=True
-)

--- a/experiment/baseline_tcp.py
+++ b/experiment/baseline_tcp.py
@@ -1,6 +1,0 @@
-import subprocess
-
-subprocess.run(
-    "./src/iperf3 -c localhost -p 5201 --json --logfile ./output/baseline_tcp.log",
-    shell=True
-)

--- a/experiment/baseline_udp.py
+++ b/experiment/baseline_udp.py
@@ -1,6 +1,0 @@
-import subprocess
-
-subprocess.run(
-    "./src/iperf3 -c localhost -p 5201 --udp --json --logfile ./output/baseline_udp.log",
-    shell=True
-)


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any): #9

* Brief description of code changes (suitable for use as a commit message):

Added new QUIC protocol configuration. Only a few basic things are added to address the issue:

* `id` (set to `0x100` temporarily)
* `name`
* Other variables like `accept` and `recv` are set to temporary functions that for now just return the results of UDP or TCP functions. These were necessary to be able to test the functionality of the JSON output.

I tested the output with the client options `-J --quic`, `-J --quic -P 2`, `-J --quic -R`, and `-J --quic -R -P 2`. These all function, and the output includes `"protocol": "QUIC"` in the JSON output, achieving the goal of the issue that this PR addresses.

TCP and UDP functionality have been tested and their behavior remains unchanged.